### PR TITLE
Increase header menu text size

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,11 +100,11 @@
                 <span class="font-playfair text-4xl font-bold text-teal tracking-normal">Ngô Khôi</span>
             </a>
             <nav class="hidden md:flex items-center space-x-8 font-medium">
-                <a href="#process" class="text-light-gray hover:text-teal transition-colors duration-300">Quy Trình</a>
-                <a href="#valuation" class="text-light-gray hover:text-teal transition-colors duration-300">Định Giá</a>
-                <a href="#recent-purchases" class="text-light-gray hover:text-teal transition-colors duration-300">Xe Đã Mua</a>
-                <a href="#brands" class="text-light-gray hover:text-teal transition-colors duration-300">Thương Hiệu</a>
-                <a href="#footer" class="text-light-gray hover:text-teal transition-colors duration-300">Liên Hệ</a>
+                <a href="#process" class="text-light-gray hover:text-teal transition-colors duration-300 text-lg">Quy Trình</a>
+                <a href="#valuation" class="text-light-gray hover:text-teal transition-colors duration-300 text-lg">Định Giá</a>
+                <a href="#recent-purchases" class="text-light-gray hover:text-teal transition-colors duration-300 text-lg">Xe Đã Mua</a>
+                <a href="#brands" class="text-light-gray hover:text-teal transition-colors duration-300 text-lg">Thương Hiệu</a>
+                <a href="#footer" class="text-light-gray hover:text-teal transition-colors duration-300 text-lg">Liên Hệ</a>
             </nav>
             <button id="mobile-menu-button" class="md:hidden text-light-gray focus:outline-none">
                 <svg id="mobile-menu-open" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg>
@@ -113,11 +113,11 @@
         </div>
         <!-- Mobile Menu -->
         <div id="mobile-menu" class="hidden md:hidden bg-dark-slate-light">
-            <a href="#process" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300">Quy Trình</a>
-            <a href="#valuation" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300">Định Giá</a>
-            <a href="#recent-purchases" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300">Xe Đã Mua</a>
-            <a href="#brands" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300">Thương Hiệu</a>
-            <a href="#footer" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300">Liên Hệ</a>
+            <a href="#process" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300 text-lg">Quy Trình</a>
+            <a href="#valuation" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300 text-lg">Định Giá</a>
+            <a href="#recent-purchases" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300 text-lg">Xe Đã Mua</a>
+            <a href="#brands" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300 text-lg">Thương Hiệu</a>
+            <a href="#footer" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300 text-lg">Liên Hệ</a>
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- enlarge the header navigation text on desktop and mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6878c6872ae0832688e1c3c826efd5e0