### PR TITLE
Add Ford showcase navigation and section

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,7 @@
             <nav class="hidden md:flex items-center space-x-8 font-medium">
                 <a href="#process" class="text-light-gray hover:text-teal transition-colors duration-300 text-lg">Quy Trình</a>
                 <a href="#valuation" class="text-light-gray hover:text-teal transition-colors duration-300 text-lg">Định Giá</a>
+                <a href="#ford-showcase" class="text-light-gray hover:text-teal transition-colors duration-300 text-lg">Xe Ford Mới</a>
                 <a href="#recent-purchases" class="text-light-gray hover:text-teal transition-colors duration-300 text-lg">Xe Đã Mua</a>
                 <a href="#brands" class="text-light-gray hover:text-teal transition-colors duration-300 text-lg">Thương Hiệu</a>
                 <a href="#footer" class="text-light-gray hover:text-teal transition-colors duration-300 text-lg">Liên Hệ</a>
@@ -186,6 +187,7 @@
         <div id="mobile-menu" class="hidden md:hidden bg-dark-slate-light">
             <a href="#process" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300 text-lg">Quy Trình</a>
             <a href="#valuation" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300 text-lg">Định Giá</a>
+            <a href="#ford-showcase" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300 text-lg">Xe Ford Mới</a>
             <a href="#recent-purchases" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300 text-lg">Xe Đã Mua</a>
             <a href="#brands" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300 text-lg">Thương Hiệu</a>
             <a href="#footer" class="block text-center py-3 px-4 text-light-gray hover:bg-teal hover:text-dark-slate transition-colors duration-300 text-lg">Liên Hệ</a>
@@ -206,6 +208,33 @@
                 <a href="#valuation" class="inline-block mt-10 px-12 py-4 bg-teal text-dark-slate font-inter text-lg font-bold hover:bg-teal-darker transition-colors duration-300 rounded-md">
                     Yêu Cầu Định Giá Ngay
                 </a>
+            </div>
+        </section>
+
+        <!-- Ford Showcase Section -->
+        <section id="ford-showcase" class="py-20 md:py-32 bg-dark-slate scroll-mt-24">
+            <div class="container mx-auto px-6">
+                <div class="max-w-3xl mx-auto text-center">
+                    <h2 class="font-playfair text-4xl md:text-5xl font-bold text-white">Xe Ford Mới Chính Hãng</h2>
+                    <p class="mt-4 font-inter text-lg text-light-gray/80 leading-relaxed">Đại Lý Ford Nam Sài Gòn - Giá Tốt &amp; Giao Ngay</p>
+                </div>
+                <div class="mt-12 grid grid-cols-1 md:grid-cols-3 gap-8 md:gap-10">
+                    <div class="rounded-2xl border border-teal bg-dark-slate-light p-8 shadow-lg">
+                        <h3 class="font-inter text-2xl font-semibold text-white">Ford Ranger</h3>
+                        <p class="mt-4 font-inter text-base text-light-gray/80 leading-relaxed">Bán tải mạnh mẽ, trang bị an toàn tiên tiến, sẵn xe giao ngay cho mọi hành trình.</p>
+                        <a href="#valuation" class="mt-6 inline-block px-6 py-3 bg-teal text-dark-slate font-inter font-semibold rounded-md hover:bg-teal-darker transition-colors duration-300">Nhận Báo Giá</a>
+                    </div>
+                    <div class="rounded-2xl border border-teal bg-dark-slate-light p-8 shadow-lg">
+                        <h3 class="font-inter text-2xl font-semibold text-white">Ford Everest</h3>
+                        <p class="mt-4 font-inter text-base text-light-gray/80 leading-relaxed">SUV 7 chỗ đẳng cấp, thiết kế hiện đại cùng khoang nội thất rộng rãi và tiện nghi.</p>
+                        <a href="#valuation" class="mt-6 inline-block px-6 py-3 bg-teal text-dark-slate font-inter font-semibold rounded-md hover:bg-teal-darker transition-colors duration-300">Nhận Báo Giá</a>
+                    </div>
+                    <div class="rounded-2xl border border-teal bg-dark-slate-light p-8 shadow-lg">
+                        <h3 class="font-inter text-2xl font-semibold text-white">Ford Territory</h3>
+                        <p class="mt-4 font-inter text-base text-light-gray/80 leading-relaxed">Crossover thông minh, tiết kiệm nhiên liệu cùng gói công nghệ hỗ trợ lái ưu việt.</p>
+                        <a href="#valuation" class="mt-6 inline-block px-6 py-3 bg-teal text-dark-slate font-inter font-semibold rounded-md hover:bg-teal-darker transition-colors duration-300">Nhận Báo Giá</a>
+                    </div>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add "Xe Ford Mới" navigation entries to both desktop and mobile menus
- introduce a Ford showcase section with hero copy and three vehicle highlight cards featuring CTA buttons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d7506001ac8326a249a80acc9f6005