### PR TITLE
Add imagery to Ford showcase cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,17 +220,26 @@
                 </div>
                 <div class="mt-12 grid grid-cols-1 md:grid-cols-3 gap-8 md:gap-10">
                     <div class="rounded-2xl border border-teal bg-dark-slate-light p-8 shadow-lg">
-                        <h3 class="font-inter text-2xl font-semibold text-white">Ford Ranger</h3>
+                        <div class="rounded-xl overflow-hidden">
+                            <img src="./showroom/raptor.png" alt="Ford Ranger" class="w-full h-52 object-cover">
+                        </div>
+                        <h3 class="mt-6 font-inter text-2xl font-semibold text-white">Ford Ranger</h3>
                         <p class="mt-4 font-inter text-base text-light-gray/80 leading-relaxed">Bán tải mạnh mẽ, trang bị an toàn tiên tiến, sẵn xe giao ngay cho mọi hành trình.</p>
                         <a href="#valuation" class="mt-6 inline-block px-6 py-3 bg-teal text-dark-slate font-inter font-semibold rounded-md hover:bg-teal-darker transition-colors duration-300">Nhận Báo Giá</a>
                     </div>
                     <div class="rounded-2xl border border-teal bg-dark-slate-light p-8 shadow-lg">
-                        <h3 class="font-inter text-2xl font-semibold text-white">Ford Everest</h3>
+                        <div class="rounded-xl overflow-hidden">
+                            <img src="./showroom/everest.png" alt="Ford Everest" class="w-full h-52 object-cover">
+                        </div>
+                        <h3 class="mt-6 font-inter text-2xl font-semibold text-white">Ford Everest</h3>
                         <p class="mt-4 font-inter text-base text-light-gray/80 leading-relaxed">SUV 7 chỗ đẳng cấp, thiết kế hiện đại cùng khoang nội thất rộng rãi và tiện nghi.</p>
                         <a href="#valuation" class="mt-6 inline-block px-6 py-3 bg-teal text-dark-slate font-inter font-semibold rounded-md hover:bg-teal-darker transition-colors duration-300">Nhận Báo Giá</a>
                     </div>
                     <div class="rounded-2xl border border-teal bg-dark-slate-light p-8 shadow-lg">
-                        <h3 class="font-inter text-2xl font-semibold text-white">Ford Territory</h3>
+                        <div class="rounded-xl overflow-hidden">
+                            <img src="./showroom/territory.png" alt="Ford Territory" class="w-full h-52 object-cover">
+                        </div>
+                        <h3 class="mt-6 font-inter text-2xl font-semibold text-white">Ford Territory</h3>
                         <p class="mt-4 font-inter text-base text-light-gray/80 leading-relaxed">Crossover thông minh, tiết kiệm nhiên liệu cùng gói công nghệ hỗ trợ lái ưu việt.</p>
                         <a href="#valuation" class="mt-6 inline-block px-6 py-3 bg-teal text-dark-slate font-inter font-semibold rounded-md hover:bg-teal-darker transition-colors duration-300">Nhận Báo Giá</a>
                     </div>


### PR DESCRIPTION
## Summary
- add dedicated vehicle imagery to each Ford showroom card
- space the card headings below the new media blocks for improved layout

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_b_68d766e6b304832681756c04212cb246